### PR TITLE
CTLD updates

### DIFF
--- a/ctld.lua
+++ b/ctld.lua
@@ -65,7 +65,7 @@ ctld.enabledFOBBuilding = true -- if true, you can load a crate INTO a C-130 tha
 -- In future i'd like it to be a FARP but so far that seems impossible...
 -- You can also enable troop Pickup at FOBS
 
-ctld.cratesRequiredForFOB = 3 -- The amount of crates required to build a FOB. Once built, helis can spawn crates at this outpost to be carried and deployed in another area.
+ctld.cratesRequiredForFOB = 1 -- The amount of crates required to build a FOB. Once built, helis can spawn crates at this outpost to be carried and deployed in another area.
 -- The large crates can only be loaded and dropped by large aircraft, like the C-130 and listed in ctld.vehicleTransportEnabled
 -- Small FOB crates can be moved by helicopter. The FOB will require ctld.cratesRequiredForFOB larges crates and small crates are 1/3 of a large fob crate
 -- To build the FOB entirely out of small crates you will need ctld.cratesRequiredForFOB * 3

--- a/ctld.lua
+++ b/ctld.lua
@@ -4255,7 +4255,7 @@ function ctld.orderGroupToMoveToPoint(_leader, _destination)
       _controller:setTask(_arg[2])
     end
   end
-  , {_group:getName(), _mission}, timer.getTime() + 2)
+  , {_group:getName(), _mission}, timer.getTime() + 10)
 
 end
 


### PR DESCRIPTION
Reduced FOB crates required to 1

Re Issue #164, if you guys think it's worth doing.

I still think the main issue is with the red SEAD frequency/weapons, but it might be worth a shot to tweak.

Edited the AI time-in for dropped troops to 10 seconds. This will make it easier to see if CTLD related lag spikes are happening due to spawn or AI activation. Note that the default search distance is 4km, so we have some super inefficient pathfinding code happening if 10 troops overloads the server.